### PR TITLE
add return to 'make_request' class method

### DIFF
--- a/pocket.py
+++ b/pocket.py
@@ -151,7 +151,7 @@ class Pocket(object):
 
     @classmethod
     def make_request(cls, url, payload, headers=None):
-        cls._make_request(url, payload, headers)
+        return cls._make_request(url, payload, headers)
 
     @method_wrapper
     def add(self, url, title=None, tags=None, tweet_id=None):


### PR DESCRIPTION
Using the latest release from pypi I found that none of the calls were returning anything. Seems like this was left out in the 'code cleanup' refactor 3279b7263592491a3fc9bfbba886f7c328a0c003
