### PR TITLE
Fix python3.4 compatibility

### DIFF
--- a/pocket.py
+++ b/pocket.py
@@ -63,7 +63,7 @@ def bulk_wrapper(fn):
 
     @wraps(fn)
     def wrapped(self, *args, **kwargs):
-        arg_names = list(fn.func_code.co_varnames)
+        arg_names = list(fn.__code__.co_varnames)
         arg_names.remove('self')
         kwargs.update(dict(zip(arg_names, args)))
 


### PR DESCRIPTION
Previous python3.4 update missed the `func_code` in the `bulk_wrapper` function.