### PR TITLE
Suggest to run browser with auth_url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ request_token = Pocket.get_request_token(consumer_key=consumer_key, redirect_uri
 
 # URL to redirect user to, to authorize your app
 auth_url = Pocket.get_auth_url(code=request_token, redirect_uri=redirect_uri)
+# e.g. import subprocess; subprocess.run(['xdg-open', auth_url])
 
 user_credentials = Pocket.get_credentials(consumer_key=consumer_key, code=request_token)
 


### PR DESCRIPTION
Hi! Minor thing, but at first I just copy-pasted the oauth example and missed the part where I have to open URL. Perhaps this would make it a bit more obvious :) 